### PR TITLE
Bump gherkin from 27.0.0 to 28.0.0 in /gremlin-dotnet

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,11 +4,11 @@ jobs:
   smoke:
     name: smoke
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -18,29 +18,29 @@ jobs:
     name: mvn clean install - jdk11
     timeout-minutes: 45
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -pl -:gremlin-javascript,-:gremlin-dotnet-source,-:gremlin-dotnet-tests,-:gremlin-go,-:gremlin-python -Dci --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dcoverage
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044
         with:
          directory: ./gremlin-tools/gremlin-coverage/target/site
   java-jdk8:
     name: mvn clean install - jdk8
     timeout-minutes: 45
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -50,11 +50,11 @@ jobs:
     name: gremlin-server default
     timeout-minutes: 45
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -66,11 +66,11 @@ jobs:
     name: gremlin-server unified
     timeout-minutes: 45
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -82,11 +82,11 @@ jobs:
       name: cache gremlin-server docker image
       timeout-minutes: 10
       needs: smoke
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         - name: Set up JDK 11
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
           with:
             java-version: '11'
             distribution: 'temurin'
@@ -106,7 +106,7 @@ jobs:
             key: ${{ github.sha }}
          # Disabled until Linux containers are supported on Windows runners: https://github.com/actions/virtual-environments/issues/252
 #        - name: Upload Docker image for Windows
-#          uses: actions/upload-artifact@v3
+#          uses: actions/upload-artifact@v4
 #          with:
 #            name: ${{ github.sha }}
 #            path: ./gremlin-server/gremlin-server.tar
@@ -118,11 +118,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-2022]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -142,11 +142,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-2022]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -163,11 +163,11 @@ jobs:
     name: gremlin-console
     timeout-minutes: 20
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -180,11 +180,11 @@ jobs:
     name: gremlin-driver
     timeout-minutes: 20
     needs: cache-gremlin-server-docker-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -200,17 +200,17 @@ jobs:
     strategy:
       matrix:
         # Windows Disabled until Linux containers are supported on Windows runners: https://github.com/actions/virtual-environments/issues/252
-        # os: [ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        # os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Get Cached Server Base Image
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions/cache@v4
         id: gremlin-server-test-docker-image
         with:
@@ -219,7 +219,7 @@ jobs:
             ~/.m2/repository/org/apache/tinkerpop/*
           key: ${{ github.sha }}
 #      - name: Download Server Base Image
-#        if: matrix.os == 'windows-latest'
+#        if: matrix.os == 'windows-2022'
 #        uses: actions/download-artifact@v3
 #        with:
 #          name: ${{ github.sha }}
@@ -235,16 +235,16 @@ jobs:
     name: python
     timeout-minutes: 20
     needs: cache-gremlin-server-docker-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: '3.8'
       - name: Build with Maven
@@ -256,16 +256,16 @@ jobs:
     name: .NET
     timeout-minutes: 20
     needs: cache-gremlin-server-docker-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Set up .NET 6.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3
         with:
           dotnet-version: '6.0.x'
       - name: Get Cached Server Base Image
@@ -289,11 +289,11 @@ jobs:
     name: neo4j-gremlin
     timeout-minutes: 20
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -305,12 +305,12 @@ jobs:
     name: go
     timeout-minutes: 20
     needs: cache-gremlin-server-docker-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version: '1.20'
       - name: Get Cached Server Base Image
@@ -331,7 +331,7 @@ jobs:
           mvn clean install -pl -:gremlin-python,-:gremlin-javascript,-:gremlin-dotnet,-:gremlin-dotnet-source,-:gremlin-dotnet-tests -q -DskipTests -Dci
           mvn verify -pl :gremlin-go
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044
         with:
           working-directory: ./gremlin-go
       - name: Go-Vet


### PR DESCRIPTION
pr_rerun dependabot/nuget/gremlin-dotnet/3.6-dev/gherkin-28.0.0 to 3.6-dev